### PR TITLE
Add API proxy

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -365,7 +365,7 @@ curl localhost:8080/api/mqtt/clients
 
 Response:
 ```
-[{"ID":"cf1up11t673b49rllusg","ProtocolVersion":4,"Username":"cmVjb3JkZXI=","CleanSession":true,"Done":false,"Subscriptions":{"recorder":{"ShareName":null,"Filter":"recorder","Identifier":0,"Identifiers":null,"RetainHandling":0,"Qos":2,"RetainAsPublished":false,"NoLocal":false}}}]
+[{"ID":"cf1up11t673b49rllusg","ProtocolVersion":4,"Username":"recorder","CleanSession":true,"Done":false,"Subscriptions":{"recorder":{"ShareName":null,"Filter":"recorder","Identifier":0,"Identifiers":null,"RetainHandling":0,"Qos":2,"RetainAsPublished":false,"NoLocal":false}}}]
 ```
 
 ### :8080/api/mqtt/client/stop
@@ -411,7 +411,7 @@ Request params:
 
 Response:
 ```
-[{"Payload":"b25saW5l","Topic":"red/available","Retain":true,"Qos":0},{"Payload":"MQ==","Topic":"nfc2mqtt/online","Retain":true,"Qos":0}]
+[{"Connect":{"willProperties":{"cd":null,"si":null,"ad":null,"user":null,"ct":"","rt":"","aci":"","am":"","ri":"","sr":"","rs":"","me":0,"sei":0,"wdi":0,"mps":0,"ska":0,"rm":0,"tam":0,"ta":0,"pf":0,"fpf":false,"fsei":false,"fska":false,"rpi":0,"frpi":false,"rri":0,"fta":false,"mqos":0,"fmqos":false,"ra":0,"fra":false,"wsa":0,"fwsa":false,"sida":0,"fsida":false,"ssa":0,"fssa":false},"password":null,"username":null,"protocolName":null,"willPayload":null,"clientId":"","willTopic":"","keepalive":0,"passwordFlag":false,"usernameFlag":false,"willQos":0,"willFlag":false,"willRetain":false,"clean":false},"Properties":{"cd":null,"si":null,"ad":null,"user":null,"ct":"","rt":"","aci":"","am":"","ri":"","sr":"","rs":"","me":0,"sei":0,"wdi":0,"mps":0,"ska":0,"rm":0,"tam":0,"ta":0,"pf":0,"fpf":false,"fsei":false,"fska":false,"rpi":0,"frpi":false,"rri":0,"fta":false,"mqos":0,"fmqos":false,"ra":0,"fra":false,"wsa":0,"fwsa":false,"sida":0,"fsida":false,"ssa":0,"fssa":false},"Payload":"dGVzdA==","ReasonCodes":null,"Filters":null,"TopicName":"TestMqttTopicMessagesHandler","Origin":"inline","FixedHeader":{"remaining":0,"type":3,"qos":0,"dup":false,"retain":true},"Created":1673825332,"Expiry":0,"Mods":{"MaxSize":0,"DisallowProblemInfo":false,"AllowResponseInfo":false},"PacketID":0,"ProtocolVersion":4,"SessionPresent":false,"ReasonCode":0,"ReservedBit":0}]
 ```
 
 ### :8080/api/mqtt/topic/subscribers

--- a/Readme.md
+++ b/Readme.md
@@ -258,6 +258,8 @@ api:
 
 All `/api` prefixed endpoints will return `200` on success, `400` on wrong request or `500` when request cant be executed.
 
+Some `/api` endpoints are supporting `/proxy` prefix. This allow to send request to single `broker-ha` instance and get combined response from every node in the cluster.
+
 ### :8080/metrics endpoint
 
 Expose Prometheus metrics.
@@ -340,7 +342,7 @@ event: cluster:message_from
 data: {"Payload":"MA==","Topic":"red/action/event","Retain":false,"Qos":0}
 ```
 
-### :8080/api/discovery/members
+### :8080/api/discovery/members | :8080/proxy/api/discovery/members
 
 Return discovery (memberlist) members.
 
@@ -354,7 +356,7 @@ Response:
 [{"Name":"broker-ha-6ffc959cff-v5495","Addr":"10.42.2.242","Port":7946,"Meta":"","State":0,"PMin":1,"PMax":5,"PCur":2,"DMin":0,"DMax":0,"DCur":0},{"Name":"broker-ha-6ffc959cff-v62ct","Addr":"10.42.1.14","Port":7946,"Meta":"","State":0,"PMin":1,"PMax":5,"PCur":2,"DMin":0,"DMax":0,"DCur":0},{"Name":"broker-ha-6ffc959cff-mrzrk","Addr":"10.42.0.205","Port":7946,"Meta":"","State":0,"PMin":1,"PMax":5,"PCur":2,"DMin":0,"DMax":0,"DCur":0}]
 ```
 
-### :8080/api/mqtt/clients
+### :8080/api/mqtt/clients | :8080/proxy/api/mqtt/clients
 
 Return MQTT broker clients.
 
@@ -380,7 +382,7 @@ curl localhost:8080/api/mqtt/client/stop -d '{"client_id": "cf1up11t673b49rllusg
 Request params:
 - client_id - MQTT client ID.
 
-### :8080/api/client/inflight
+### :8080/api/mqtt/client/inflight | :8080/proxy/api/mqtt/client/inflight
 
 Return MQTT in-flight messages for client.
 
@@ -397,7 +399,7 @@ Response:
 [{"Connect":{"willProperties":{"cd":null,"si":null,"ad":null,"user":null,"ct":"","rt":"","aci":"","am":"","ri":"","sr":"","rs":"","me":0,"sei":0,"wdi":0,"mps":0,"ska":0,"rm":0,"tam":0,"ta":0,"pf":0,"fpf":false,"fsei":false,"fska":false,"rpi":0,"frpi":false,"rri":0,"fta":false,"mqos":0,"fmqos":false,"ra":0,"fra":false,"wsa":0,"fwsa":false,"sida":0,"fsida":false,"ssa":0,"fssa":false},"password":null,"username":null,"protocolName":null,"willPayload":null,"clientId":"","willTopic":"","keepalive":0,"passwordFlag":false,"usernameFlag":false,"willQos":0,"willFlag":false,"willRetain":false,"clean":false},"Properties":{"cd":null,"si":[0],"ad":null,"user":null,"ct":"","rt":"","aci":"","am":"","ri":"","sr":"","rs":"","me":0,"sei":0,"wdi":0,"mps":0,"ska":0,"rm":0,"tam":0,"ta":0,"pf":0,"fpf":false,"fsei":false,"fska":false,"rpi":0,"frpi":false,"rri":0,"fta":false,"mqos":0,"fmqos":false,"ra":0,"fra":false,"wsa":0,"fwsa":false,"sida":0,"fsida":false,"ssa":0,"fssa":false},"Payload":"dGVzdA==","ReasonCodes":null,"Filters":null,"TopicName":"TestMqttClientInflightHandler","Origin":"inline","FixedHeader":{"remaining":0,"type":3,"qos":2,"dup":false,"retain":true},"Created":1673806755,"Expiry":1673807355,"Mods":{"MaxSize":0,"DisallowProblemInfo":false,"AllowResponseInfo":false},"PacketID":1,"ProtocolVersion":4,"SessionPresent":false,"ReasonCode":0,"ReservedBit":0}]
 ```
 
-### :8080/api/mqtt/topic/messages
+### :8080/api/mqtt/topic/messages | :8080/proxy/api/mqtt/topic/messages
 
 Return MQTT retained messages for topic.
 
@@ -414,7 +416,7 @@ Response:
 [{"Connect":{"willProperties":{"cd":null,"si":null,"ad":null,"user":null,"ct":"","rt":"","aci":"","am":"","ri":"","sr":"","rs":"","me":0,"sei":0,"wdi":0,"mps":0,"ska":0,"rm":0,"tam":0,"ta":0,"pf":0,"fpf":false,"fsei":false,"fska":false,"rpi":0,"frpi":false,"rri":0,"fta":false,"mqos":0,"fmqos":false,"ra":0,"fra":false,"wsa":0,"fwsa":false,"sida":0,"fsida":false,"ssa":0,"fssa":false},"password":null,"username":null,"protocolName":null,"willPayload":null,"clientId":"","willTopic":"","keepalive":0,"passwordFlag":false,"usernameFlag":false,"willQos":0,"willFlag":false,"willRetain":false,"clean":false},"Properties":{"cd":null,"si":null,"ad":null,"user":null,"ct":"","rt":"","aci":"","am":"","ri":"","sr":"","rs":"","me":0,"sei":0,"wdi":0,"mps":0,"ska":0,"rm":0,"tam":0,"ta":0,"pf":0,"fpf":false,"fsei":false,"fska":false,"rpi":0,"frpi":false,"rri":0,"fta":false,"mqos":0,"fmqos":false,"ra":0,"fra":false,"wsa":0,"fwsa":false,"sida":0,"fsida":false,"ssa":0,"fssa":false},"Payload":"dGVzdA==","ReasonCodes":null,"Filters":null,"TopicName":"TestMqttTopicMessagesHandler","Origin":"inline","FixedHeader":{"remaining":0,"type":3,"qos":0,"dup":false,"retain":true},"Created":1673825332,"Expiry":0,"Mods":{"MaxSize":0,"DisallowProblemInfo":false,"AllowResponseInfo":false},"PacketID":0,"ProtocolVersion":4,"SessionPresent":false,"ReasonCode":0,"ReservedBit":0}]
 ```
 
-### :8080/api/mqtt/topic/subscribers
+### :8080/api/mqtt/topic/subscribers | :8080/proxy/api/mqtt/topic/subscribers
 
 Return MQTT client ID and QoS for subscription topic.
 

--- a/integration_test.go
+++ b/integration_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 	"time"
 
+	"brokerha/internal/api"
+
 	"github.com/alexliesenfeld/health"
 	paho "github.com/eclipse/paho.mqtt.golang"
 	"github.com/hashicorp/memberlist"
@@ -130,7 +132,7 @@ func TestBrokerHA(t *testing.T) {
 	require.Equal(t, []byte("test"), mqttMessage.Payload(), "wrong payload")
 
 	for _, endpoint := range []string{"ready", "healthz"} {
-		resp, err := http.Get(fmt.Sprintf("http://127.0.0.1:8080/%s", endpoint))
+		resp, err := http.Get(fmt.Sprintf("http://127.0.0.1:%d/%s", api.HTTPPort, endpoint))
 
 		require.Equal(t, 200, resp.StatusCode, fmt.Sprintf("unexpected status code for %s endpoint", endpoint))
 		require.Nil(t, err, fmt.Sprintf("unexpected error for %s endpoint", endpoint))
@@ -144,7 +146,7 @@ func TestBrokerHA(t *testing.T) {
 	time.Sleep(15 * time.Second)
 
 	for _, endpoint := range []string{"ready", "healthz"} {
-		resp, err := http.Get(fmt.Sprintf("http://127.0.0.1:8080/%s", endpoint))
+		resp, err := http.Get(fmt.Sprintf("http://127.0.0.1:%d/%s", api.HTTPPort, endpoint))
 
 		require.Equal(t, 503, resp.StatusCode, fmt.Sprintf("unexpected status code for %s endpoint", endpoint))
 		require.Nil(t, err, fmt.Sprintf("unexpected error for %s endpoint", endpoint))

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -23,6 +25,189 @@ import (
 	"brokerha/internal/discovery"
 	"brokerha/internal/types"
 )
+
+func TestProxyHandler(t *testing.T) {
+	tests := []struct {
+		inputReqFunc  func() *http.Request
+		inputServers  func() []*http.Server
+		expectedCode  int
+		expectedError string
+		expectedBody  map[string]interface{}
+	}{
+		{
+			inputReqFunc: func() *http.Request {
+				r := httptest.NewRequest(http.MethodGet, "/proxy/api/discovery/members", nil)
+				r.Body = errReader(0)
+				return r
+			},
+			expectedCode:  http.StatusBadRequest,
+			expectedError: "test error",
+		},
+		{
+			inputReqFunc: func() *http.Request {
+				r := httptest.NewRequest(http.MethodGet, "/proxy/api/discovery/members", nil)
+				r.Method = "*?"
+				return r
+			},
+			expectedCode:  http.StatusBadRequest,
+			expectedError: "net/http: invalid method \"*?\"",
+		},
+		{
+			inputReqFunc: func() *http.Request {
+				r := httptest.NewRequest(http.MethodGet, "/proxy/api/discovery/members", nil)
+				return r
+			},
+			expectedCode:  http.StatusBadRequest,
+			expectedError: "Get \"http://127.0.0.1:8080/api/discovery/members\": dial tcp 127.0.0.1:8080: connect: connection refused",
+		},
+		{
+			inputReqFunc: func() *http.Request {
+				r := httptest.NewRequest(http.MethodGet, "/proxy/api/discovery/members", nil)
+				return r
+			},
+			inputServers: func() []*http.Server {
+				h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.Header().Set("Content-Length", "1")
+					fmt.Fprintln(w, "Hello")
+				})
+				s := &http.Server{Addr: fmt.Sprintf("127.0.0.1:%d", HTTPPort), Handler: h}
+				return []*http.Server{s}
+			},
+			expectedCode:  http.StatusBadRequest,
+			expectedError: "unexpected EOF",
+		},
+		{
+			inputReqFunc: func() *http.Request {
+				r := httptest.NewRequest(http.MethodGet, "/proxy/api/discovery/members", nil)
+				r.Header.Add("test-header", "test")
+				return r
+			},
+			inputServers: func() []*http.Server {
+				h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					require.Equal(t, "test", r.Header.Get("test-header"))
+					require.Equal(t, "/api/discovery/members", r.URL.Path)
+					require.Equal(t, http.MethodGet, r.Method)
+
+					w.Header().Set("Content-Type", "application/json")
+					fmt.Fprintln(w, "{\"a\": \"b\"}")
+				})
+				s := &http.Server{Addr: fmt.Sprintf("127.0.0.1:%d", HTTPPort), Handler: h}
+				return []*http.Server{s}
+			},
+			expectedCode: http.StatusOK,
+			expectedBody: map[string]interface{}{
+				"node1": map[string]interface{}{
+					"a": "b",
+				},
+				"node2": map[string]interface{}{
+					"a": "b",
+				},
+			},
+		},
+		{
+			inputReqFunc: func() *http.Request {
+				r := httptest.NewRequest(http.MethodPost, "/proxy/api/mqtt/client/inflight", strings.NewReader("{'client_id': 'test'}"))
+				r.Header.Add("test-header", "test2")
+				return r
+			},
+			inputServers: func() []*http.Server {
+				h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					require.Equal(t, "test2", r.Header.Get("test-header"))
+					require.Equal(t, "/api/mqtt/client/inflight", r.URL.Path)
+					require.Equal(t, http.MethodPost, r.Method)
+
+					reqBody, err := io.ReadAll(r.Body)
+					require.Nil(t, err)
+					require.Equal(t, []byte("{'client_id': 'test'}"), reqBody)
+
+					w.Header().Set("Content-Type", "application/json")
+					fmt.Fprintln(w, "{\"c\": \"d\"}")
+				})
+				s := &http.Server{Addr: fmt.Sprintf("127.0.0.1:%d", HTTPPort), Handler: h}
+				return []*http.Server{s}
+			},
+			expectedCode: http.StatusOK,
+			expectedBody: map[string]interface{}{
+				"node1": map[string]interface{}{
+					"c": "d",
+				},
+				"node2": map[string]interface{}{
+					"c": "d",
+				},
+			},
+		},
+	}
+	mlConfig1 := memberlist.DefaultLocalConfig()
+	mlConfig1.BindAddr = "127.0.0.1"
+	mlConfig1.BindPort = 7946
+	mlConfig1.AdvertisePort = 7946
+	mlConfig1.Name = "node1"
+	mlConfig1.LogOutput = ioutil.Discard
+
+	evBus := bus.New()
+	disco, ctxCancel, err := discovery.New(&discovery.Options{
+		Domain:           "test",
+		MemberListConfig: mlConfig1,
+		Bus:              evBus,
+		SubscriptionSize: map[string]int{"cluster:message_to": 1024},
+	})
+	require.Nil(t, err)
+	defer disco.Shutdown()
+	defer ctxCancel()
+
+	mlConfig2 := memberlist.DefaultLocalConfig()
+	mlConfig2.BindAddr = "127.0.0.1"
+	mlConfig2.BindPort = 7947
+	mlConfig2.AdvertisePort = 7947
+	mlConfig2.Name = "node2"
+	mlConfig2.LogOutput = ioutil.Discard
+	m2, err := memberlist.Create(mlConfig2)
+	require.Nil(t, err)
+	defer m2.Shutdown()
+
+	_, err = m2.Join([]string{"127.0.0.1:7946"})
+	require.Nil(t, err)
+
+	handler := proxyHandler(disco)
+
+	for _, test := range tests {
+		w := httptest.NewRecorder()
+		req := test.inputReqFunc()
+		var servers []*http.Server
+		if test.inputServers != nil {
+			servers = test.inputServers()
+			if len(servers) > 0 {
+				for _, s := range servers {
+					go s.ListenAndServe()
+				}
+			}
+		}
+		handler(w, req)
+		res := w.Result()
+		defer res.Body.Close()
+
+		if len(servers) > 0 {
+			for _, s := range servers {
+				s.Shutdown(context.TODO())
+			}
+		}
+
+		require.Equal(t, test.expectedCode, w.Code)
+
+		if w.Code != http.StatusOK {
+			resp := make(map[string]string)
+			unmarshalBody(res.Body, &resp)
+
+			if test.expectedError != "" {
+				require.Equal(t, test.expectedError, resp["error"])
+			}
+		} else {
+			resp := make(map[string]interface{})
+			unmarshalBody(res.Body, &resp)
+			require.Equal(t, test.expectedBody, resp)
+		}
+	}
+}
 
 func TestSseHandler(t *testing.T) {
 	tests := []struct {
@@ -747,6 +932,16 @@ func unmarshalBody(body io.Reader, destination interface{}) interface{} {
 		panic("unable to unmarshal body")
 	}
 	return destination
+}
+
+type errReader int
+
+func (errReader) Read(p []byte) (n int, err error) {
+	return 0, errors.New("test error")
+}
+
+func (errReader) Close() error {
+	return nil
 }
 
 type ResponseWriter interface {

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -631,7 +631,7 @@ func TestMqttTopicMessagesHandler(t *testing.T) {
 				require.Equal(t, test.expectedError, resp["error"])
 			}
 		} else {
-			var resp []*types.MQTTPublishMessage
+			var resp []packets.Packet
 			unmarshalBody(res.Body, &resp)
 			require.Equal(t, test.expectedMessages, len(resp))
 		}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -22,10 +22,9 @@ func NewRouter(opts *Options) *chi.Mux {
 	httpRouter.Group(func(r chi.Router) {
 		r.Use(middleware.CleanPath)
 		if len(opts.AuthUsers) > 0 {
-			log.Printf("basic auth for API HTTP endpoint enabled")
 			r.Use(middleware.BasicAuth("api", opts.AuthUsers))
 		} else {
-			log.Printf("basic auth for API HTTP endpoint disabled")
+			log.Printf("auth for HTTP API disabled")
 		}
 		r.Use(middleware.Recoverer)
 

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -29,6 +29,12 @@ func NewRouter(opts *Options) *chi.Mux {
 		}
 		r.Use(middleware.Recoverer)
 
+		r.Get("/proxy/api/discovery/members", proxyHandler(opts.Discovery))
+		r.Get("/proxy/api/mqtt/clients", proxyHandler(opts.Discovery))
+		r.Post("/proxy/api/mqtt/client/inflight", proxyHandler(opts.Discovery))
+		r.Post("/proxy/api/mqtt/topic/messages", proxyHandler(opts.Discovery))
+		r.Post("/proxy/api/mqtt/topic/subscribers", proxyHandler(opts.Discovery))
+
 		r.Post("/api/sse", sseHandler(opts.Bus))
 		r.Get("/api/discovery/members", discoveryMembersHandler(opts.Discovery))
 		r.Get("/api/mqtt/clients", mqttClientsHandler(opts.Broker))

--- a/internal/api/router_test.go
+++ b/internal/api/router_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -103,6 +104,24 @@ func TestNewRouter(t *testing.T) {
 		},
 		{
 			inputMethod:  http.MethodGet,
+			inputPath:    "/proxy/api/discovery/members",
+			expectedCode: http.StatusOK,
+		},
+		{
+			inputMethod:  http.MethodGet,
+			inputPath:    "/proxy/api/discovery/members",
+			expectedCode: http.StatusUnauthorized,
+			auth:         map[string]string{"test": "test"},
+		},
+		{
+			inputMethod:  http.MethodGet,
+			inputPath:    "/proxy/api/discovery/members",
+			inputAuth:    [2]string{"test", "test"},
+			expectedCode: http.StatusOK,
+			auth:         map[string]string{"test": "test"},
+		},
+		{
+			inputMethod:  http.MethodGet,
 			inputPath:    "/api/mqtt/clients",
 			expectedCode: http.StatusOK,
 		},
@@ -120,6 +139,24 @@ func TestNewRouter(t *testing.T) {
 			auth:         map[string]string{"test": "test"},
 		},
 		{
+			inputMethod:  http.MethodGet,
+			inputPath:    "/proxy/api/mqtt/clients",
+			expectedCode: http.StatusOK,
+		},
+		{
+			inputMethod:  http.MethodGet,
+			inputPath:    "/proxy/api/mqtt/clients",
+			expectedCode: http.StatusUnauthorized,
+			auth:         map[string]string{"test": "test"},
+		},
+		{
+			inputMethod:  http.MethodGet,
+			inputPath:    "/proxy/api/mqtt/clients",
+			inputAuth:    [2]string{"test", "test"},
+			expectedCode: http.StatusOK,
+			auth:         map[string]string{"test": "test"},
+		},
+		{
 			inputMethod:  http.MethodPost,
 			inputPath:    "/api/mqtt/client/stop",
 			expectedCode: http.StatusBadRequest,
@@ -157,6 +194,24 @@ func TestNewRouter(t *testing.T) {
 		},
 		{
 			inputMethod:  http.MethodPost,
+			inputPath:    "/proxy/api/mqtt/client/inflight",
+			expectedCode: http.StatusOK,
+		},
+		{
+			inputMethod:  http.MethodPost,
+			inputPath:    "/proxy/api/mqtt/client/inflight",
+			expectedCode: http.StatusUnauthorized,
+			auth:         map[string]string{"test": "test"},
+		},
+		{
+			inputMethod:  http.MethodPost,
+			inputPath:    "/proxy/api/mqtt/client/inflight",
+			inputAuth:    [2]string{"test", "test"},
+			expectedCode: http.StatusOK,
+			auth:         map[string]string{"test": "test"},
+		},
+		{
+			inputMethod:  http.MethodPost,
 			inputPath:    "/api/mqtt/topic/messages",
 			expectedCode: http.StatusBadRequest,
 		},
@@ -175,6 +230,24 @@ func TestNewRouter(t *testing.T) {
 		},
 		{
 			inputMethod:  http.MethodPost,
+			inputPath:    "/proxy/api/mqtt/topic/messages",
+			expectedCode: http.StatusOK,
+		},
+		{
+			inputMethod:  http.MethodPost,
+			inputPath:    "/proxy/api/mqtt/topic/messages",
+			expectedCode: http.StatusUnauthorized,
+			auth:         map[string]string{"test": "test"},
+		},
+		{
+			inputMethod:  http.MethodPost,
+			inputPath:    "/proxy/api/mqtt/topic/messages",
+			inputAuth:    [2]string{"test", "test"},
+			expectedCode: http.StatusOK,
+			auth:         map[string]string{"test": "test"},
+		},
+		{
+			inputMethod:  http.MethodPost,
 			inputPath:    "/api/mqtt/topic/subscribers",
 			expectedCode: http.StatusBadRequest,
 		},
@@ -189,6 +262,24 @@ func TestNewRouter(t *testing.T) {
 			inputPath:    "/api/mqtt/topic/subscribers",
 			inputAuth:    [2]string{"test", "test"},
 			expectedCode: http.StatusBadRequest,
+			auth:         map[string]string{"test": "test"},
+		},
+		{
+			inputMethod:  http.MethodPost,
+			inputPath:    "/proxy/api/mqtt/topic/subscribers",
+			expectedCode: http.StatusOK,
+		},
+		{
+			inputMethod:  http.MethodPost,
+			inputPath:    "/proxy/api/mqtt/topic/subscribers",
+			expectedCode: http.StatusUnauthorized,
+			auth:         map[string]string{"test": "test"},
+		},
+		{
+			inputMethod:  http.MethodPost,
+			inputPath:    "/proxy/api/mqtt/topic/subscribers",
+			inputAuth:    [2]string{"test", "test"},
+			expectedCode: http.StatusOK,
 			auth:         map[string]string{"test": "test"},
 		},
 	}
@@ -249,6 +340,10 @@ func TestNewRouter(t *testing.T) {
 			AuthUsers:              test.auth,
 			Bus:                    evBus,
 		})
+
+		httpServer := &http.Server{Addr: fmt.Sprintf(":%d", HTTPPort), Handler: router}
+		go httpServer.ListenAndServe()
+		defer httpServer.Shutdown(context.TODO())
 
 		router.ServeHTTP(w, req)
 

--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -122,17 +122,8 @@ func (b *Broker) SystemInfo() *system.Info {
 
 // Messages returns stored messages based on filter.
 // Filter can use regular MQTT wildcards (#, +).
-func (b *Broker) Messages(filter string) []*types.MQTTPublishMessage {
-	var messages []*types.MQTTPublishMessage
-	for _, m := range b.server.Topics.Messages(filter) {
-		messages = append(messages, &types.MQTTPublishMessage{
-			Payload: m.Payload,
-			Topic:   m.TopicName,
-			Retain:  m.FixedHeader.Retain,
-			Qos:     m.FixedHeader.Qos,
-		})
-	}
-	return messages
+func (b *Broker) Messages(filter string) []packets.Packet {
+	return b.server.Topics.Messages(filter)
 }
 
 // Clients returns all MQTT clients.
@@ -219,9 +210,9 @@ func (b *Broker) handleNewMember(ctx context.Context, ch chan bus.Event) {
 			for _, message := range b.Messages("#") {
 				m := types.DiscoveryPublishMessage{
 					Payload: message.Payload,
-					Topic:   message.Topic,
-					Retain:  message.Retain,
-					Qos:     message.Qos,
+					Topic:   message.TopicName,
+					Retain:  message.FixedHeader.Retain,
+					Qos:     message.FixedHeader.Qos,
 					Node:    []string{member},
 				}
 				b.bus.Publish("cluster:message_to", m)

--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -21,7 +21,7 @@ import (
 type MQTTClient struct {
 	ID              string
 	ProtocolVersion byte
-	Username        []byte
+	Username        string
 	CleanSession    bool
 	Done            bool
 	Subscriptions   map[string]packets.Subscription
@@ -142,7 +142,7 @@ func (b *Broker) Clients() []*MQTTClient {
 		clients = append(clients, &MQTTClient{
 			ID:              c.ID,
 			ProtocolVersion: c.Properties.ProtocolVersion,
-			Username:        c.Properties.Username,
+			Username:        string(c.Properties.Username),
 			CleanSession:    c.Properties.Clean,
 			Done:            c.Closed(),
 			Subscriptions:   c.State.Subscriptions.GetAll(),
@@ -160,7 +160,7 @@ func (b *Broker) Client(clientID string) (*MQTTClient, error) {
 	return &MQTTClient{
 		ID:              client.ID,
 		ProtocolVersion: client.Properties.ProtocolVersion,
-		Username:        client.Properties.Username,
+		Username:        string(client.Properties.Username),
 		CleanSession:    client.Properties.Clean,
 		Done:            client.Closed(),
 		Subscriptions:   client.State.Subscriptions.GetAll(),

--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -73,7 +73,7 @@ func New(opts *Options) (*Broker, context.CancelFunc, error) {
 			return nil, nil, err
 		}
 	} else {
-		log.Printf("auth for mqtt disabled")
+		log.Printf("auth for MQTT disabled")
 		if err := mqttServer.AddHook(new(auth.AllowHook), nil); err != nil {
 			return nil, nil, err
 		}

--- a/internal/broker/broker_test.go
+++ b/internal/broker/broker_test.go
@@ -263,44 +263,64 @@ func TestSystemInfo(t *testing.T) {
 func TestMessages(t *testing.T) {
 	tests := []struct {
 		inputFilter      string
-		expectedMessages []*types.MQTTPublishMessage
+		expectedMessages []packets.Packet
 	}{
 		{
 			inputFilter: "test",
-			expectedMessages: []*types.MQTTPublishMessage{
+			expectedMessages: []packets.Packet{
 				{
-					Topic:   "test",
-					Payload: []byte("test"),
-					Qos:     0,
-					Retain:  true,
+					TopicName:       "test",
+					Payload:         []byte("test"),
+					Origin:          "inline",
+					ProtocolVersion: 4,
+					FixedHeader: packets.FixedHeader{
+						Qos:    0,
+						Retain: true,
+						Type:   3,
+					},
 				},
 			},
 		},
 		{
 			inputFilter: "test2",
-			expectedMessages: []*types.MQTTPublishMessage{
+			expectedMessages: []packets.Packet{
 				{
-					Topic:   "test2",
-					Payload: []byte("test2"),
-					Qos:     0,
-					Retain:  true,
+					TopicName:       "test2",
+					Payload:         []byte("test2"),
+					Origin:          "inline",
+					ProtocolVersion: 4,
+					FixedHeader: packets.FixedHeader{
+						Qos:    0,
+						Retain: true,
+						Type:   3,
+					},
 				},
 			},
 		},
 		{
 			inputFilter: "#",
-			expectedMessages: []*types.MQTTPublishMessage{
+			expectedMessages: []packets.Packet{
 				{
-					Topic:   "test",
-					Payload: []byte("test"),
-					Qos:     0,
-					Retain:  true,
+					TopicName:       "test",
+					Payload:         []byte("test"),
+					Origin:          "inline",
+					ProtocolVersion: 4,
+					FixedHeader: packets.FixedHeader{
+						Qos:    0,
+						Retain: true,
+						Type:   3,
+					},
 				},
 				{
-					Topic:   "test2",
-					Payload: []byte("test2"),
-					Qos:     0,
-					Retain:  true,
+					TopicName:       "test2",
+					Payload:         []byte("test2"),
+					Origin:          "inline",
+					ProtocolVersion: 4,
+					FixedHeader: packets.FixedHeader{
+						Qos:    0,
+						Retain: true,
+						Type:   3,
+					},
 				},
 			},
 		},
@@ -316,12 +336,17 @@ func TestMessages(t *testing.T) {
 
 	broker.server.Publish("test", []byte("test"), true, 0)
 	broker.server.Publish("test2", []byte("test2"), true, 0)
+	now := time.Now().Unix()
 
-	time.Sleep(200 * time.Millisecond)
+	time.Sleep(100 * time.Millisecond)
 
 	for _, test := range tests {
 		messages := broker.Messages(test.inputFilter)
-		require.ElementsMatch(t, test.expectedMessages, messages)
+		for idx, pk := range test.expectedMessages {
+			pk.Created = now
+			test.expectedMessages[idx] = pk
+		}
+		require.Equal(t, test.expectedMessages, messages)
 	}
 }
 

--- a/internal/broker/broker_test.go
+++ b/internal/broker/broker_test.go
@@ -181,7 +181,7 @@ func TestNew(t *testing.T) {
 				"cluster broker started",
 				"starting handleNewMember worker",
 				"starting publishToMQTT worker",
-				"auth for mqtt disabled",
+				"auth for MQTT disabled",
 			},
 		},
 		{

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"log"
 	"net/http"
 	"sync"
@@ -96,7 +97,7 @@ func main() {
 
 	go func() {
 		defer wg.Done()
-		log.Fatal(http.ListenAndServe(":8080", httpRouter))
+		log.Fatal(http.ListenAndServe(fmt.Sprintf(":%d", api.HTTPPort), httpRouter))
 	}()
 
 	if err := d.FormCluster(minInitSleep, maxInitSleep); err != nil {


### PR DESCRIPTION
Some API endpoints now supports `/proxy` prefix. This allow to send API request to single `broker-ha` instance, and receive combined response from all cluster members.